### PR TITLE
The current 'active' page generates sematically correct span element

### DIFF
--- a/src/X.PagedList.Mvc/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc/HtmlHelper.cs
@@ -66,7 +66,7 @@ namespace PagedList.Mvc
             var format = options.FunctionToDisplayEachPageNumber
                 ?? (pageNumber => string.Format(options.LinkToIndividualPageFormat, pageNumber));
             var targetPageNumber = i;
-            var page = new TagBuilder("a");
+            var page = i == list.PageNumber ? new TagBuilder("span") : new TagBuilder("a");
             page.SetInnerText(format(targetPageNumber));
 
             if (i == list.PageNumber)


### PR DESCRIPTION
This is a fix for issue: https://github.com/ernado-x/X.PagedList/issues/10

Instead of generating an anchor html element without src, a span element is created.